### PR TITLE
use loadTestsFromTestCase as makeSuite is deprecated

### DIFF
--- a/pygrace/tests/test_interactive.py
+++ b/pygrace/tests/test_interactive.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
     import shutil
     installed = bool(shutil.which('xmgrace'))
     if installed:
-        suite0 = unittest.makeSuite(PyGrace_PyGrace_TestCase)
+        suite0 = unittest.defaultTestLoader.loadTestsFromTestCase(PyGrace_PyGrace_TestCase)
         alltests = (suite0,)
         alltests = unittest.TestSuite(alltests)
         unittest.TextTestRunner(verbosity=2).run(alltests)


### PR DESCRIPTION
## Summary
use loadTestsFromTestCase as makeSuite is deprecated

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.