### PR TITLE
formal support for python 3.12, build for 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,26 @@ matrix:
 
         - python: '3.11'
           env:
-            - CYTHON="true" # numpy source build
 
-        - python: '3.12-dev'
+        - python: '3.12'
+          env:
+
+        - python: '3.13-dev'
           env:
             - CYTHON="true" # numpy source build
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.12
+        - python: 'pypy3.9-7.3.9' # at 7.3.13
           env:
 
-        - python: 'pypy3.10-7.3.12'
+        - python: 'pypy3.10-7.3.13'
           env:
 
     allow_failures:
-        - python: '3.12-dev'
-        - python: 'pypy3.10-7.3.12' # CI missing
+        - python: '3.13-dev'
+        - python: 'pypy3.10-7.3.13' # CI missing
     fast_finish: true
 
 cache:

--- a/pygrace/base.py
+++ b/pygrace/base.py
@@ -460,7 +460,7 @@ class GraceObject(object):
     def _latex_friendly(self, string):
         """Return a string that won't make latex complain, for example escape
         all underscores."""
-        return string.replace('_', '\_').replace('&', '\&')
+        return string.replace('_', r'\_').replace('&', r'\&')
 
     def cheatsheet(self, filename):
         """produce a latex file listing the object's attributes and methods"""

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_kwds = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py310-numpy12
     py311-numpy12
     py312-numpy12
+    py313-numpy12
     pypy38-numpy12
     pypy39-numpy12
     pypy310-numpy12
@@ -21,6 +22,7 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
     pypy38: pypy38
     pypy39: pypy39
     pypy310: pypy310


### PR DESCRIPTION
## Summary
add formal support for python 3.12, infrastructure to build 3.13

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.