### PR TITLE
Bump jinja2 from 3.1.5 to 3.1.6 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ exceptiongroup==1.2.2
 h11==0.14.0
 idna==3.10
 imagesize==1.4.1
-jinja2==3.1.5
+jinja2==3.1.6
 markdown-it-py==3.0.0
 markupsafe==3.0.2
 mdit-py-plugins==0.4.2


### PR DESCRIPTION
## Summary
Bump jinja2 from 3.1.5 to 3.1.6 in /docs
