### PR TITLE
drop formal support for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 
 matrix:
     include:
-        - python: '3.8'
-          env:
-
         - python: '3.9'
           env:
             - COVERAGE="true"
@@ -25,9 +22,6 @@ matrix:
         - python: '3.14-dev'
           env:
             - CYTHON="true" # numpy source build
-
-        - python: 'pypy3.8-7.3.9' # at 7.3.11
-          env:
 
         - python: 'pypy3.9-7.3.9' # at 7.3.16
           env:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Requirements
 ------------
 ``pygrace`` requires:
 
-* ``python`` (or ``pypy``), **>=3.8**
+* ``python`` (or ``pypy``), **>=3.9**
 * ``setuptools``, **>=42**
 * ``cython``, **>=0.29.30**
 * ``numpy``, **>=1.0**

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@
 import os
 import sys
 # drop support for older python
-if sys.version_info < (3, 8):
-    unsupported = 'Versions of Python before 3.8 are not supported'
+if sys.version_info < (3, 9):
+    unsupported = 'Versions of Python before 3.9 are not supported'
     raise ValueError(unsupported)
 
 # get distribution meta info
@@ -59,14 +59,13 @@ setup_kwds = dict(
         'Source Code':'https://github.com/uqfoundation/pygrace',
         'Bug Tracker':'https://github.com/uqfoundation/pygrace/issues',
     },
-    python_requires = '>=3.8',
+    python_requires = '>=3.9',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -2,32 +2,30 @@
 skip_missing_interpreters=
     True
 envlist =
-    py38-numpy12
     py39-numpy12
     py310-numpy12
     py311-numpy12
     py312-numpy12
     py313-numpy12
     py314-numpy12
-    pypy38-numpy12
     pypy39-numpy12
     pypy310-numpy12
+    pypy311-numpy12
 
 [testenv]
 setenv =
     PYTHONHASHSEED = 0
     recreate = True
 basepython = 
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
     py313: python3.13
     py314: python3.14
-    pypy38: pypy38
     pypy39: pypy39
     pypy310: pypy310
+    pypy311: pypy311
 deps =
     numpy12: numpy>=1.0
 whitelist_externals =


### PR DESCRIPTION
## Summary
drop formal support for python 3.8
Closes: #38 
